### PR TITLE
feat: 이메일 인증 및 비밀번호 재설정을 위한 auth_code 테이블 추가

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -10,6 +10,21 @@ CREATE TABLE `member` (
   `created_at` datetime DEFAULT (CURRENT_TIMESTAMP)
 );
 
+CREATE TABLE `auth_code` (
+  `auth_code_id` int PRIMARY KEY AUTO_INCREMENT,
+  `email` varchar(255) NOT NULL,
+  `code_hash` varchar(255) NOT NULL,
+  `expires_at` datetime NOT NULL,
+  `used_at` datetime,
+  `created_at` datetime DEFAULT (CURRENT_TIMESTAMP)
+);
+
+CREATE INDEX idx_auth_code_email
+  ON auth_code (email);
+
+CREATE INDEX idx_auth_code_expires_at
+  ON auth_code (expires_at);
+
 CREATE TABLE `item_category` (
   `category_id` int PRIMARY KEY AUTO_INCREMENT,
   `category_name` varchar(50) NOT NULL,
@@ -60,6 +75,8 @@ CREATE TABLE `bank_account` (
 );
 
 ALTER TABLE `member` COMMENT = '학생(회원) 정보';
+
+ALTER TABLE `auth_code` COMMENT = '이메일 인증번호 (비밀번호 재설정, 이메일 인증)';
 
 ALTER TABLE `item_category` COMMENT = '비품 카테고리 (우산/보조배터리 등)';
 


### PR DESCRIPTION
- 이메일 인증번호를 저장하기 위한 auth_code 테이블을 생성함
- 조회 성능 향상을 위해 email, expires_at 컬럼에 인덱스 추가
- auth_code 테이블의 용도를 명확히 하기 위해 테이블 설명(Comment) 추가